### PR TITLE
Support for i386 arch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@ UBUNTU_BOXES= precise quantal raring saucy trusty
 DEBIAN_BOXES= squeeze wheezy sid jessie
 TODAY=$(shell date -u +"%Y-%m-%d")
 
+# Replace i686 with i386
+ARCH=$(shell uname -m | sed -e "s/68/38/")
+
 default:
 
 all: ubuntu debian
@@ -10,26 +13,26 @@ ubuntu: $(UBUNTU_BOXES)
 debian: $(DEBIAN_BOXES)
 
 # REFACTOR: Figure out how can we reduce duplicated code
-$(UBUNTU_BOXES): CONTAINER = "vagrant-base-${@}-amd64"
-$(UBUNTU_BOXES): PACKAGE = "output/${TODAY}/vagrant-lxc-${@}-amd64.box"
+$(UBUNTU_BOXES): CONTAINER = "vagrant-base-${@}-$(ARCH)"
+$(UBUNTU_BOXES): PACKAGE = "output/${TODAY}/vagrant-lxc-${@}-$(ARCH).box"
 $(UBUNTU_BOXES):
 	@mkdir -p $$(dirname $(PACKAGE))
-	@sudo -E ./mk-debian.sh ubuntu $(@) amd64 $(CONTAINER) $(PACKAGE)
+	@sudo -E ./mk-debian.sh ubuntu $(@) $(ARCH) $(CONTAINER) $(PACKAGE)
 	@sudo chmod +rw $(PACKAGE)
 	@sudo chown ${USER}: $(PACKAGE)
-$(DEBIAN_BOXES): CONTAINER = "vagrant-base-${@}-amd64"
-$(DEBIAN_BOXES): PACKAGE = "output/${TODAY}/vagrant-lxc-${@}-amd64.box"
+$(DEBIAN_BOXES): CONTAINER = "vagrant-base-${@}-$(ARCH)"
+$(DEBIAN_BOXES): PACKAGE = "output/${TODAY}/vagrant-lxc-${@}-$(ARCH).box"
 $(DEBIAN_BOXES):
 	@mkdir -p $$(dirname $(PACKAGE))
-	@sudo -E ./mk-debian.sh debian $(@) amd64 $(CONTAINER) $(PACKAGE)
+	@sudo -E ./mk-debian.sh debian $(@) $(ARCH) $(CONTAINER) $(PACKAGE)
 	@sudo chmod +rw $(PACKAGE)
 	@sudo chown ${USER}: $(PACKAGE)
 
-acceptance: CONTAINER = "vagrant-base-acceptance-amd64"
-acceptance: PACKAGE = "output/${TODAY}/vagrant-lxc-acceptance-amd64.box"
+acceptance: CONTAINER = "vagrant-base-acceptance-$(ARCH)"
+acceptance: PACKAGE = "output/${TODAY}/vagrant-lxc-acceptance-$(ARCH).box"
 acceptance:
 	@mkdir -p $$(dirname $(PACKAGE))
-	@PUPPET=1 CHEF=1 sudo -E ./mk-debian.sh ubuntu precise amd64 $(CONTAINER) $(PACKAGE)
+	@PUPPET=1 CHEF=1 sudo -E ./mk-debian.sh ubuntu precise $(ARCH) $(CONTAINER) $(PACKAGE)
 	@sudo chmod +rw $(PACKAGE)
 	@sudo chown ${USER}: $(PACKAGE)
 
@@ -37,6 +40,6 @@ clean: ALL_BOXES = ${DEBIAN_BOXES} ${UBUNTU_BOXES} acceptance
 clean:
 	@for r in $(ALL_BOXES); do \
 		sudo -E ./clean.sh $${r}\
-		                   vagrant-base-$${r}-amd64 \
-				               output/${TODAY}/vagrant-lxc-$${r}-amd64.box; \
+		                   vagrant-base-$${r}-$(ARCH) \
+				               output/${TODAY}/vagrant-lxc-$${r}-$(ARCH).box; \
 		done


### PR DESCRIPTION
Sad that I have to use a i686 computer to do some of my work. And your vagrant-lxc helps a lot. This change will make it possible to create i686 boxes as well.

Thanks!
