### PR TITLE
Remove limitation for installing Puppet on trusty, 3.6.0 available from PuppetLabs repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,5 +63,5 @@ See [vagrant-lxc/BOXES.md](https://github.com/fgrehm/vagrant-lxc/blob/master/BOX
 
 * We can't get the NFS client to be installed on the containers used for building
   Ubuntu 13.04 / 13.10 / 14.04 base boxes.
-* Puppet can't be installed on Ubuntu 14.04 / Debian Sid
+* Puppet can't be installed on Debian Sid
 * Salt can't be installed on Ubuntu 13.04

--- a/debian/install-extras.sh
+++ b/debian/install-extras.sh
@@ -55,8 +55,6 @@ fi
 if [ $PUPPET = 1 ]; then
   if $(lxc-attach -n ${CONTAINER} -- which puppet &>/dev/null); then
     log "Puppet has been installed on container, skipping"
-  elif [ ${RELEASE} = 'trusty' ]; then
-    warn "Puppet can't be installed on Ubuntu Trusty 14.04, skipping"
   elif [ ${RELEASE} = 'sid' ]; then
     warn "Puppet can't be installed on Debian sid, skipping"
   else


### PR DESCRIPTION
Hi,

as from 3.6.0 release Puppet became available for Ubuntu Trusty from PuppetLabs repo.

Here I've removed the conditional to print the warning and skipping Puppet installation when building a Trusty based container.

The container contains the following packages:

```
facter  2.0.1-1puppetlabs1
hiera   1.3.2-1puppetlabs1
puppet  3.6.0-1puppetlabs1
puppet-common   3.6.0-1puppetlabs1
puppetlabs-release      1.0-7
```

As reference: http://docs.puppetlabs.com/puppet/latest/reference/release_notes.html#os-support-changes

Let me know if I've missed anything else that should be modified.
