### PR TITLE
Make sure ssh is installed on Trusty

### DIFF
--- a/debian/install-extras.sh
+++ b/debian/install-extras.sh
@@ -14,7 +14,7 @@ log 'Sleeping for 5 seconds...'
 sleep 5
 
 # TODO: Support for appending to this list from outside
-PACKAGES=(vim curl wget man-db bash-completion python-software-properties ca-certificates sudo)
+PACKAGES=(vim curl wget man-db bash-completion python-software-properties ca-certificates sudo ssh)
 if [ $DISTRIBUTION = 'ubuntu' ]; then
   PACKAGES+=' software-properties-common'
 fi


### PR DESCRIPTION
I built an Ubuntu 14.04 box and the resulting container was without ssh server.

Given that openssh-server is essential for vagrant to work I added it to the package list. 