### PR TITLE
Updated centos/install-extras.sh script + Added feature to create custom vagrant boxes based on running lxc container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /log
 /output
-rootfs
+rootfs*
 custom
+/update*

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /log
 /output
+rootfs
+custom

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ release:
 	git push && git push --tags
 
 own_box:
-	@sudo -E ./mk-custom.sh ${ACTIVE_CONTAINER}
+	@sudo -E ./mk-custom.sh ${ACTIVE_CONTAINER} ${USER}
 
 clean: ALL_BOXES = ${DEBIAN_BOXES} ${UBUNTU_BOXES} ${CENTOS_BOXES} acceptance
 clean:

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,9 @@ release:
 	git tag $(version)
 	git push && git push --tags
 
+own_box:
+	@sudo -E ./mk-custom.sh ${ACTIVE_CONTAINER}
+
 clean: ALL_BOXES = ${DEBIAN_BOXES} ${UBUNTU_BOXES} ${CENTOS_BOXES} acceptance
 clean:
 	@for r in $(ALL_BOXES); do \

--- a/README.md
+++ b/README.md
@@ -43,6 +43,13 @@ make precise
 Will build a Ubuntu Precise x86_64 box with latest Puppet, Chef, Salt and
 Babushka pre-installed.
 
+```sh
+ACTIVE_CONTAINER=lxc-container-name \
+make own_box
+```
+
+Will try to build a vagrant box from an activily running lxc container. Make sure you configured the
+container for [vagrant](https://github.com/fgrehm/vagrant-lxc/blob/master/BOXES.md)!
 
 ## Pre built base boxes
 

--- a/centos/install-extras.sh
+++ b/centos/install-extras.sh
@@ -16,5 +16,5 @@ sleep 10
 utils.lxc.attach yum update -y
 
 # TODO: Support for appending to this list from outside
-PACKAGES=(vim curl wget man-db bash-completion python-software-properties ca-certificates sudo nfs-common)
+PACKAGES=(vim curl wget man-db bash-completion python-software-properties ca-certificates sudo nfs-common openssh-server)
 utils.lxc.attach yum install ${PACKAGES[*]} -y

--- a/centos/install-extras.sh
+++ b/centos/install-extras.sh
@@ -18,3 +18,18 @@ utils.lxc.attach yum update -y
 # TODO: Support for appending to this list from outside
 PACKAGES=(vim curl wget man-db bash-completion python-software-properties ca-certificates sudo nfs-common openssh-server)
 utils.lxc.attach yum install ${PACKAGES[*]} -y
+
+# Puppet provisioner
+PUPPET=${PUPPET:=0}
+
+if [ $PUPPET = 1 ]; then
+  if $(lxc-attach -n ${CONTAINER} -- which puppet &>/dev/null); then
+    log "Puppet has been installed on container, skipping"
+  else
+    log "Installing Puppet"
+    wget http://yum.puppetlabs.com/puppetlabs-release-el-${RELEASE}.noarch.rpm -O "${ROOTFS}/tmp/puppetlabs-release-stable.rpm" &>>${LOG}
+    utils.lxc.attach rpm -Uvh "/tmp/puppetlabs-release-stable.rpm"
+    utils.lxc.attach yum update -y
+    utils.lxc.attach yum install puppet -y
+  fi
+fi

--- a/centos/install-extras.sh
+++ b/centos/install-extras.sh
@@ -19,6 +19,9 @@ utils.lxc.attach yum update -y
 PACKAGES=(vim curl wget man-db bash-completion python-software-properties ca-certificates sudo nfs-common openssh-server)
 utils.lxc.attach yum install ${PACKAGES[*]} -y
 
+# Disabling iptables modules reloading
+utils.lxc.attach sed -i 's/IPTABLES_MODULES_UNLOAD=\"yes\"/IPTABLES_MODULES_UNLOAD=\"no\"/g' /etc/sysconfig/iptables-config
+
 # Puppet provisioner
 PUPPET=${PUPPET:=0}
 

--- a/conf/centos
+++ b/conf/centos
@@ -28,7 +28,8 @@ lxc.hook.clone = /usr/share/lxc/hooks/clonehostname
 # lxc.cap.drop = audit_control    # breaks sshd (set_loginuid failed)
 # lxc.cap.drop = audit_write
 #
-lxc.cap.drop = mac_admin mac_override setfcap setpcap
+#lxc.cap.drop = mac_admin mac_override setfcap setpcap
+lxc.cap.drop = mac_admin mac_override
 lxc.cap.drop = sys_module sys_nice sys_pacct
 lxc.cap.drop = sys_rawio sys_time
 
@@ -45,6 +46,12 @@ lxc.cgroup.devices.allow = c 1:8 rwm	# /dev/random
 lxc.cgroup.devices.allow = c 1:9 rwm	# /dev/urandom
 lxc.cgroup.devices.allow = c 136:* rwm	# /dev/tty[1-4] ptys and lxc console
 lxc.cgroup.devices.allow = c 5:2 rwm	# /dev/ptmx pty master
+
+# Needed by default docker config
+lxc.cgroup.devices.allow = c 5:1 rwm # /dev/console
+lxc.cgroup.devices.allow = c 4:0 rwm # /dev/tty0
+lxc.cgroup.devices.allow = c 4:1 rwm # /dev/tty1
+lxc.cgroup.devices.allow = c 10:200 rwm # /dev/net/tun
 
 # Blacklist some syscalls which are not safe in privileged
 # containers

--- a/mk-custom.sh
+++ b/mk-custom.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Declare parameters
+NAME=$1
+
+# Stop the lxc container if running
+lxc-stop -n $NAME
+
+# Remove the previous working dir if existing
+if [ -d custom/$NAME ]; then
+	rm custom/$NAME -rf
+fi
+
+# Creat working dir
+mkdir custom/$NAME
+
+# Create tar file of lxc container
+cd /var/lib/lxc/boekentoren-puppet-development/
+tar --numeric-owner --anchored --exclude=./rootfs/dev/log -czf rootfs.tar.gz ./rootfs/*
+chown jan: rootfs.tar.gz
+mv rootfs.tar.gz /home/Jan/Projecten/Github.com/vagrant-lxc-base-boxes/custom/$NAME
+
+# Build working dir structure
+cd /home/Jan/Projecten/Github.com/vagrant-lxc-base-boxes/custom/$NAME
+cp ../../conf/centos lxc-config
+cp ../../conf/metadata.json .
+sed -i "s/<TODAY>/${NOW}/" metadata.json
+
+# Create actual vagrant box file
+tar -czf $NAME.box ./*
+cd ../../
+ls custom/$NAME/$NAME.box


### PR DESCRIPTION
Added openssh-server package for enabling the ssh server on a centos box and copied over the puppet provisioner part from the debian installer so it works for a centos box too.
Wrote a mk-custom.sh script which creates a vagrant box based on a running lxc-container.