### PR TITLE
centos 7 target and config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 UBUNTU_BOXES= precise quantal raring saucy trusty
 DEBIAN_BOXES= squeeze wheezy sid jessie
-CENTOS_BOXES= 6
+CENTOS_BOXES= 6 7
 TODAY=$(shell date -u +"%Y-%m-%d")
 
 # Replace i686 with i386 and x86_64 with amd64

--- a/centos/install-extras.sh
+++ b/centos/install-extras.sh
@@ -16,5 +16,5 @@ sleep 10
 utils.lxc.attach yum update -y
 
 # TODO: Support for appending to this list from outside
-PACKAGES=(vim curl wget man-db bash-completion python-software-properties ca-certificates sudo nfs-common)
+PACKAGES=(vim curl wget man-db bash-completion python-software-properties ca-certificates sudo nfs-common openssh-server)
 utils.lxc.attach yum install ${PACKAGES[*]} -y

--- a/conf/centos
+++ b/conf/centos
@@ -28,9 +28,17 @@ lxc.hook.clone = /usr/share/lxc/hooks/clonehostname
 # lxc.cap.drop = audit_control    # breaks sshd (set_loginuid failed)
 # lxc.cap.drop = audit_write
 #
-lxc.cap.drop = mac_admin mac_override setfcap setpcap
+lxc.cap.drop = mac_admin mac_override setfcap
 lxc.cap.drop = sys_module sys_nice sys_pacct
 lxc.cap.drop = sys_rawio sys_time
+
+# This lets LXC CentOS containers run on hosts with apparmor.
+# It does nothing on hosts which do not have apparmor enabled.
+lxc.aa_profile = unconfined
+
+# Keep systemd and journald happy...
+lxc.autodev = 1
+lxc.kmsg = 0
 
 # Control Group devices: all denied except those whitelisted
 lxc.cgroup.devices.deny = a


### PR DESCRIPTION
I've added a centos 7 target and modified the centos configuration for compatibility with this target. Note that I've not extensively checked for breaking things elsewhere because of these changes. A build of this target can be found on [vagrant cloud](https://vagrantcloud.com/frensjan/boxes/centos-7-64-lxc).