### PR TITLE
Fixes to centos and debian. support utopic. support fedora 19,20,21.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 UBUNTU_BOXES= precise quantal raring saucy trusty utopic
 DEBIAN_BOXES= squeeze wheezy sid jessie
 CENTOS_BOXES= 6
-FEDORA_BOXES= 20 19
+FEDORA_BOXES= 21 20 19
 TODAY=$(shell date -u +"%Y-%m-%d")
 
 # Replace i686 with i386 and x86_64 with amd64

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,6 @@ clean: ALL_BOXES = ${DEBIAN_BOXES} ${UBUNTU_BOXES} ${CENTOS_BOXES} acceptance
 clean:
 	@for r in $(ALL_BOXES); do \
 		sudo -E ./clean.sh $${r}\
-		                   vagrant-base-$${r}-$(ARCH) \
-				               output/${TODAY}/vagrant-lxc-$${r}-$(ARCH).box; \
-		done
+			vagrant-base-$${r}-$(ARCH) \
+			output/${TODAY}/vagrant-lxc-$${r}-$(ARCH).box; \
+	done

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-UBUNTU_BOXES= precise quantal raring saucy trusty
+UBUNTU_BOXES= precise quantal raring saucy trusty utopic
 DEBIAN_BOXES= squeeze wheezy sid jessie
 CENTOS_BOXES= 6
 TODAY=$(shell date -u +"%Y-%m-%d")

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 UBUNTU_BOXES= precise quantal raring saucy trusty utopic
 DEBIAN_BOXES= squeeze wheezy sid jessie
 CENTOS_BOXES= 6
+FEDORA_BOXES= 20 19
 TODAY=$(shell date -u +"%Y-%m-%d")
 
 # Replace i686 with i386 and x86_64 with amd64
@@ -8,11 +9,12 @@ ARCH=$(shell uname -m | sed -e "s/68/38/" | sed -e "s/x86_64/amd64/")
 
 default:
 
-all: ubuntu debian
+all: ubuntu debian fedora
 
 ubuntu: $(UBUNTU_BOXES)
 debian: $(DEBIAN_BOXES)
 centos: $(CENTOS_BOXES)
+fedora: $(FEDORA_BOXES)
 
 # REFACTOR: Figure out how can we reduce duplicated code
 $(UBUNTU_BOXES): CONTAINER = "vagrant-base-${@}-$(ARCH)"
@@ -36,6 +38,13 @@ $(CENTOS_BOXES):
 	@sudo -E ./mk-centos.sh $(@) $(ARCH) $(CONTAINER) $(PACKAGE)
 	@sudo chmod +rw $(PACKAGE)
 	@sudo chown ${USER}: $(PACKAGE)
+$(FEDORA_BOXES): CONTAINER = "vagrant-base-fedora-${@}-$(ARCH)"
+$(FEDORA_BOXES): PACKAGE = "output/${TODAY}/vagrant-lxc-fedora-${@}-$(ARCH).box"
+$(FEDORA_BOXES):
+	@mkdir -p $$(dirname $(PACKAGE))
+	@sudo -E ./mk-fedora.sh $(@) $(ARCH) $(CONTAINER) $(PACKAGE)
+	@sudo chmod +rw $(PACKAGE)
+	@sudo chown ${USER}: $(PACKAGE)
 
 acceptance: CONTAINER = "vagrant-base-acceptance-$(ARCH)"
 acceptance: PACKAGE = "output/${TODAY}/vagrant-lxc-acceptance-$(ARCH).box"
@@ -51,7 +60,7 @@ release:
 	git tag $(version)
 	git push && git push --tags
 
-clean: ALL_BOXES = ${DEBIAN_BOXES} ${UBUNTU_BOXES} ${CENTOS_BOXES} acceptance
+clean: ALL_BOXES = ${DEBIAN_BOXES} ${UBUNTU_BOXES} ${CENTOS_BOXES} ${FEDORA_BOXES} acceptance
 clean:
 	@for r in $(ALL_BOXES); do \
 		sudo -E ./clean.sh $${r}\

--- a/README.md
+++ b/README.md
@@ -11,11 +11,16 @@ This repository contains a set of scripts for creating base boxes for usage with
   - Raring 13.04 x86_64
   - Saucy 13.10 x86_64
   - Trusty 14.04 x86_64
+  - Utopic 14.10 x86_64
 * Debian
   - Squeeze x86_64
   - Wheezy x86_64
   - Jessie x86_64
   - Sid x86_64
+* Fedora
+  - 19 x86_64
+  - 20 x86_64
+  - 21 x86_64
 * CentOS
   - 6 x86_64
 

--- a/centos/install-extras.sh
+++ b/centos/install-extras.sh
@@ -14,8 +14,17 @@ SECS=20
 log "Sleeping for $SECS seconds..."
 sleep $SECS
 
-utils.lxc.attach yum update -y
+# install the fedora epel repo?
+EPEL=${EPEL:-0}
 
 # TODO: Support for appending to this list from outside
 PACKAGES=(vim curl wget man ca-certificates sudo)
+
+if [ $EPEL = 1 ]; then
+  utils.lxc.attach yum update -y
+  utils.lxc.attach yum install epel-release -y
+  PACKAGES+=' bash-completion'
+fi
+
+utils.lxc.attach yum update -y
 utils.lxc.attach yum install ${PACKAGES[*]} -y

--- a/centos/install-extras.sh
+++ b/centos/install-extras.sh
@@ -17,5 +17,5 @@ sleep $SECS
 utils.lxc.attach yum update -y
 
 # TODO: Support for appending to this list from outside
-PACKAGES=(vim curl wget man-db bash-completion python-software-properties ca-certificates sudo nfs-common)
+PACKAGES=(vim curl wget man bash-completion python-software-properties ca-certificates sudo nfs-common)
 utils.lxc.attach yum install ${PACKAGES[*]} -y

--- a/centos/install-extras.sh
+++ b/centos/install-extras.sh
@@ -18,7 +18,7 @@ sleep $SECS
 EPEL=${EPEL:-0}
 
 # TODO: Support for appending to this list from outside
-PACKAGES=(vim curl wget man ca-certificates sudo)
+PACKAGES=(vim curl wget man ca-certificates sudo openssh-server)
 
 if [ $EPEL = 1 ]; then
   utils.lxc.attach yum update -y

--- a/centos/install-extras.sh
+++ b/centos/install-extras.sh
@@ -17,5 +17,5 @@ sleep $SECS
 utils.lxc.attach yum update -y
 
 # TODO: Support for appending to this list from outside
-PACKAGES=(vim curl wget man bash-completion ca-certificates sudo nfs-common)
+PACKAGES=(vim curl wget man ca-certificates sudo nfs-common)
 utils.lxc.attach yum install ${PACKAGES[*]} -y

--- a/centos/install-extras.sh
+++ b/centos/install-extras.sh
@@ -17,5 +17,5 @@ sleep $SECS
 utils.lxc.attach yum update -y
 
 # TODO: Support for appending to this list from outside
-PACKAGES=(vim curl wget man bash-completion python-software-properties ca-certificates sudo nfs-common)
+PACKAGES=(vim curl wget man bash-completion ca-certificates sudo nfs-common)
 utils.lxc.attach yum install ${PACKAGES[*]} -y

--- a/centos/install-extras.sh
+++ b/centos/install-extras.sh
@@ -10,8 +10,9 @@ debug 'Bringing container up'
 utils.lxc.start
 
 # Sleep for a bit so that the container can get an IP
-log 'Sleeping for 10 seconds...'
-sleep 10
+SECS=20
+log "Sleeping for $SECS seconds..."
+sleep $SECS
 
 utils.lxc.attach yum update -y
 

--- a/centos/install-extras.sh
+++ b/centos/install-extras.sh
@@ -17,5 +17,5 @@ sleep $SECS
 utils.lxc.attach yum update -y
 
 # TODO: Support for appending to this list from outside
-PACKAGES=(vim curl wget man ca-certificates sudo nfs-common)
+PACKAGES=(vim curl wget man ca-certificates sudo)
 utils.lxc.attach yum install ${PACKAGES[*]} -y

--- a/common/download.sh
+++ b/common/download.sh
@@ -34,6 +34,11 @@ elif [ $RELEASE = 'squeeze' ] || [ $RELEASE = 'wheezy' ]; then
   utils.lxc.create -t debian -- \
                    --release ${RELEASE} \
                    --arch ${ARCH}
+elif [ ${DISTRIBUTION} = 'fedora' -a ${RELEASE} = '21' ]; then
+  ARCH=$(echo ${ARCH} | sed -e "s/38/68/" | sed -e "s/amd64/x86_64/")
+  utils.lxc.create -t fedora --\
+                   --release ${RELEASE} \
+                   --arch ${ARCH}
 else
   utils.lxc.create -t download -- \
                    --dist ${DISTRIBUTION} \

--- a/common/prepare-vagrant-user.sh
+++ b/common/prepare-vagrant-user.sh
@@ -17,7 +17,7 @@ elif $(grep -q 'ubuntu' ${ROOTFS}/etc/shadow); then
   chroot ${ROOTFS} groupmod -n vagrant ubuntu &>> ${LOG}
   echo -n 'vagrant:vagrant' | chroot ${ROOTFS} chpasswd
   log 'Renamed ubuntu user to vagrant and changed password.'
-elif [ ${DISTRIBUTION} = 'centos' ]; then
+elif [ ${DISTRIBUTION} = 'centos' -o ${DISTRIBUTION} = 'fedora' ]; then
   debug 'Creating vagrant user...'
   chroot ${ROOTFS} useradd --create-home -s /bin/bash -u 1000 vagrant &>> ${LOG}
   echo -n 'vagrant:vagrant' | chroot ${ROOTFS} chpasswd

--- a/conf/fedora
+++ b/conf/fedora
@@ -1,0 +1,66 @@
+# work better with systemd:
+lxc.autodev = 1
+lxc.kmsg = 0
+
+# Taken from the oracle.common.conf.in
+# Console settings
+
+lxc.devttydir = lxc
+lxc.tty = 4
+lxc.pts = 1024
+
+# Mount entries
+lxc.mount.auto = proc:mixed sys:ro
+
+# Ensure hostname is changed on clone
+lxc.hook.clone = /usr/share/lxc/hooks/clonehostname
+
+# Capabilities
+# Uncomment these if you don't run anything that needs the capability, and
+# would like the container to run with less privilege.
+#
+# Dropping sys_admin disables container root from doing a lot of things
+# that could be bad like re-mounting lxc fstab entries rw for example,
+# but also disables some useful things like being able to nfs mount, and
+# things that are already namespaced with ns_capable() kernel checks, like
+# hostname(1).
+# lxc.cap.drop = sys_admin
+# lxc.cap.drop = net_raw          # breaks dhcp/ping
+# lxc.cap.drop = setgid           # breaks login (initgroups/setgroups)
+# lxc.cap.drop = dac_read_search  # breaks login (pam unix_chkpwd)
+# lxc.cap.drop = setuid           # breaks sshd,nfs statd
+# lxc.cap.drop = audit_control    # breaks sshd (set_loginuid failed)
+# lxc.cap.drop = audit_write
+# big big login delays in Fedora 20 systemd:
+#lxc.cap.drop = setpcap
+#
+lxc.cap.drop = mac_admin mac_override
+lxc.cap.drop = setfcap
+lxc.cap.drop = sys_module sys_nice sys_pacct
+lxc.cap.drop = sys_rawio sys_time
+
+# Control Group devices: all denied except those whitelisted
+lxc.cgroup.devices.deny = a
+# Allow any mknod (but not reading/writing the node)
+lxc.cgroup.devices.allow = c *:* m
+lxc.cgroup.devices.allow = b *:* m
+## /dev/null
+lxc.cgroup.devices.allow = c 1:3 rwm
+## /dev/zero
+lxc.cgroup.devices.allow = c 1:5 rwm
+## /dev/full
+lxc.cgroup.devices.allow = c 1:7 rwm
+## /dev/tty
+lxc.cgroup.devices.allow = c 5:0 rwm
+## /dev/random
+lxc.cgroup.devices.allow = c 1:8 rwm
+## /dev/urandom
+lxc.cgroup.devices.allow = c 1:9 rwm
+## /dev/tty[1-4] ptys and lxc console
+lxc.cgroup.devices.allow = c 136:* rwm
+## /dev/ptmx pty master
+lxc.cgroup.devices.allow = c 5:2 rwm
+
+# Blacklist some syscalls which are not safe in privileged
+# containers
+lxc.seccomp = /usr/share/lxc/config/common.seccomp

--- a/conf/fedora
+++ b/conf/fedora
@@ -36,7 +36,9 @@ lxc.hook.clone = /usr/share/lxc/hooks/clonehostname
 #
 lxc.cap.drop = mac_admin mac_override
 lxc.cap.drop = setfcap
-lxc.cap.drop = sys_module sys_nice sys_pacct
+lxc.cap.drop = sys_module sys_pacct
+# sys_nice: needed to run CTDB
+#lxc.cap.drop = sys_nice sys_pacct
 lxc.cap.drop = sys_rawio sys_time
 
 # Control Group devices: all denied except those whitelisted

--- a/debian/install-extras.sh
+++ b/debian/install-extras.sh
@@ -14,7 +14,7 @@ log 'Sleeping for 5 seconds...'
 sleep 5
 
 # TODO: Support for appending to this list from outside
-PACKAGES=(vim curl wget man-db bash-completion python-software-properties ca-certificates sudo)
+PACKAGES=(vim curl wget man-db bash-completion python-software-properties ca-certificates sudo openssh-server)
 if [ $DISTRIBUTION = 'ubuntu' ]; then
   PACKAGES+=' software-properties-common'
 fi

--- a/debian/install-extras.sh
+++ b/debian/install-extras.sh
@@ -10,8 +10,9 @@ debug 'Bringing container up'
 utils.lxc.start
 
 # Sleep for a bit so that the container can get an IP
-log 'Sleeping for 5 seconds...'
-sleep 5
+SECS=15
+log "Sleeping for $SECS seconds..."
+sleep $SECS
 
 # TODO: Support for appending to this list from outside
 PACKAGES=(vim curl wget man-db bash-completion python-software-properties ca-certificates sudo openssh-server)

--- a/fedora/clean.sh
+++ b/fedora/clean.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+
+source common/ui.sh
+source common/utils.sh
+
+debug 'Bringing container up'
+utils.lxc.start
+
+info "Cleaning up '${CONTAINER}'..."
+
+log 'Removing temporary files...'
+rm -rf ${ROOTFS}/tmp/*
+
+log 'cleaning up dhcp leases'
+rm -f ${ROOTFS}/var/lib/dhcp/*

--- a/fedora/install-extras.sh
+++ b/fedora/install-extras.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+source common/ui.sh
+source common/utils.sh
+
+info 'Installing extra packages and upgrading'
+
+debug 'Bringing container up'
+utils.lxc.start
+
+# Sleep for a bit so that the container can get an IP
+SECS=20
+log "Sleeping for $SECS seconds..."
+sleep $SECS
+
+# TODO: Support for appending to this list from outside
+PACKAGES=(vim curl wget man-db bash-completion ca-certificates sudo openssh-server)
+
+utils.lxc.attach yum update -y
+utils.lxc.attach yum install ${PACKAGES[*]} -y

--- a/mk-fedora.sh
+++ b/mk-fedora.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -e
+
+source common/ui.sh
+
+if [ "$(id -u)" != "0" ]; then
+  echo "You should run this script as root (sudo)."
+  exit 1
+fi
+
+export DISTRIBUTION='fedora'
+export RELEASE=$1
+export ARCH=$2
+export CONTAINER=$3
+export PACKAGE=$4
+export ROOTFS="/var/lib/lxc/${CONTAINER}/rootfs"
+export WORKING_DIR="/tmp/${CONTAINER}"
+export NOW=$(date -u)
+export LOG=$(readlink -f .)/log/${CONTAINER}.log
+
+mkdir -p $(dirname $LOG)
+echo '############################################' > ${LOG}
+echo "# Beginning build at $(date)" >> ${LOG}
+touch ${LOG}
+chmod +rw ${LOG}
+
+if [ -f ${PACKAGE} ]; then
+  warn "The box '${PACKAGE}' already exists, skipping..."
+  echo
+  exit
+fi
+
+debug "Creating ${WORKING_DIR}"
+mkdir -p ${WORKING_DIR}
+
+info "Building box to '${PACKAGE}'..."
+
+./common/download.sh ${DISTRIBUTION} ${RELEASE} ${ARCH} ${CONTAINER}
+./fedora/install-extras.sh ${CONTAINER}
+./common/prepare-vagrant-user.sh ${DISTRIBUTION} ${CONTAINER}
+./fedora/clean.sh ${CONTAINER}
+./common/package.sh ${CONTAINER} ${PACKAGE}
+
+info "Finished building '${PACKAGE}'!"
+log "Run \`sudo lxc-destroy -n ${CONTAINER}\` or \`make clean\` to remove the container that was created along the way"
+echo


### PR DESCRIPTION
Hi,

here are a few fixes to the vagrant-lxc-base-boxes repo, especially centos.
Maybe my increases to the sleeps are not acceptable generally, but on my
fedora host system, I need them... :-/

Also a few newly supported boxes: fedora 19,20,21 and ubuntu utopic.

Thanks for consideration - Michael