### PR TITLE
Create fuse device to use bindfs

### DIFF
--- a/debian/vagrant-lxc-fixes.sh
+++ b/debian/vagrant-lxc-fixes.sh
@@ -31,3 +31,7 @@ fi
 
 utils.lxc.attach /usr/sbin/locale-gen ${LANG}
 utils.lxc.attach update-locale LANG=${LANG}
+
+# Fix to allow bindfs
+utils.lxc.attach ln -s /bin/true /sbin/modprobe
+utils.lxc.attach mknod -m 666 /dev/fuse c 10 229


### PR DESCRIPTION
BindFS requires fuse access in order to proceed with the mount. To get
fuse access bindfs needs '/dev/fuse' to exist.
When BindFS is used through vagrant and vagrant-bindfs plugin it tries
to use modprobe to load fuse module, but this is impossible because
loading of kernel modules is not possible inside lxc. Be aware that
fuse kernel module must be loaded on the host machine.