### PR TITLE
Added missing openssh server package. Needed by vagrant up & vagrant ssh.

### DIFF
--- a/conf/debian
+++ b/conf/debian
@@ -12,6 +12,11 @@ lxc.pts = 1024
 # Default capabilities
 lxc.cap.drop = sys_module mac_admin mac_override sys_time
 
+# Prevent systemd-journald from burning 100% of CPU
+# See https://wiki.debian.org/LXC#Incompatibility_with_systemd
+lxc.kmsg = 0
+lxc.autodev = 1
+
 # When using LXC with apparmor, the container will be confined by default.
 # If you wish for it to instead run unconfined, copy the following line
 # (uncommented) to the container's configuration file.

--- a/debian/install-extras.sh
+++ b/debian/install-extras.sh
@@ -14,7 +14,7 @@ log 'Sleeping for 5 seconds...'
 sleep 5
 
 # TODO: Support for appending to this list from outside
-PACKAGES=(vim curl wget man-db bash-completion python-software-properties ca-certificates sudo)
+PACKAGES=(vim curl wget man-db openssh-server bash-completion python-software-properties ca-certificates sudo)
 if [ $DISTRIBUTION = 'ubuntu' ]; then
   PACKAGES+=' software-properties-common'
 fi

--- a/debian/vagrant-lxc-fixes.sh
+++ b/debian/vagrant-lxc-fixes.sh
@@ -27,6 +27,21 @@ if [ ${DISTRIBUTION} = 'debian' ]; then
   utils.lxc.attach /usr/sbin/update-rc.d -f checkroot-bootclean.sh remove
   utils.lxc.attach /usr/sbin/update-rc.d -f mountall-bootclean.sh remove
   utils.lxc.attach /usr/sbin/update-rc.d -f mountnfs-bootclean.sh remove
+
+  # Fixes for jessie, following the guide from 
+  # https://wiki.debian.org/LXC#Incompatibility_with_systemd
+  if [ "$RELEASE" = 'jessie' ]; then
+	  # Reconfigure the LXC
+	  utils.lxc.attach /bin/cp \
+		  /lib/systemd/system/getty@.service \
+		  /etc/systemd/system/getty@.service
+	  # Comment out ConditionPathExists
+	  sed -i -e 's/\(ConditionPathExists=\)/# \n# \1/' \
+		  "${ROOTFS}/etc/systemd/system/getty@.service"
+
+	  # Mask udev.service and systemd-udevd.service:
+	  utils.lxc.attach /bin/systemctl mask udev.service systemd-udevd.service
+  fi
 fi
 
 utils.lxc.attach /usr/sbin/locale-gen ${LANG}


### PR DESCRIPTION
OpenSSH server is missing from Debian Jessie template.
As said in title, SSH is needed by vagrant up & vagrant ssh.

This patch adds ``openssh-server`` during extra packages installation.

Best regards,