### PR TITLE
Prevent systemd-journald from burning 100% of CPU.

### DIFF
--- a/conf/debian
+++ b/conf/debian
@@ -12,6 +12,11 @@ lxc.pts = 1024
 # Default capabilities
 lxc.cap.drop = sys_module mac_admin mac_override sys_time
 
+# Prevent systemd-journald from burning 100% of CPU
+# See https://wiki.debian.org/LXC#Incompatibility_with_systemd
+lxc.kmsg = 0
+lxc.autodev = 1
+
 # When using LXC with apparmor, the container will be confined by default.
 # If you wish for it to instead run unconfined, copy the following line
 # (uncommented) to the container's configuration file.

--- a/debian/vagrant-lxc-fixes.sh
+++ b/debian/vagrant-lxc-fixes.sh
@@ -27,6 +27,21 @@ if [ ${DISTRIBUTION} = 'debian' ]; then
   utils.lxc.attach /usr/sbin/update-rc.d -f checkroot-bootclean.sh remove
   utils.lxc.attach /usr/sbin/update-rc.d -f mountall-bootclean.sh remove
   utils.lxc.attach /usr/sbin/update-rc.d -f mountnfs-bootclean.sh remove
+
+  # Fixes for jessie, following the guide from 
+  # https://wiki.debian.org/LXC#Incompatibility_with_systemd
+  if [ "$RELEASE" = 'jessie' ]; then
+	  # Reconfigure the LXC
+	  utils.lxc.attach /bin/cp \
+		  /lib/systemd/system/getty@.service \
+		  /etc/systemd/system/getty@.service
+	  # Comment out ConditionPathExists
+	  sed -i -e 's/\(ConditionPathExists=\)/# \n# \1/' \
+		  "${ROOTFS}/etc/systemd/system/getty@.service"
+
+	  # Mask udev.service and systemd-udevd.service:
+	  utils.lxc.attach /bin/systemctl mask udev.service systemd-udevd.service
+  fi
 fi
 
 utils.lxc.attach /usr/sbin/locale-gen ${LANG}


### PR DESCRIPTION
Apply Debian Wiki guide for LXC vs Systemd incompatibilities. Needed by Debian Jessie box.

Cf : https://wiki.debian.org/LXC#Incompatibility_with_systemd